### PR TITLE
Updating to v4 API for site_status

### DIFF
--- a/solar_analytics.yaml
+++ b/solar_analytics.yaml
@@ -333,7 +333,7 @@ rest:
   #
   # Solar Analytics - get the site status for the specified site_id.
   # Updated every hour.
-  - resource_template: https://portal.solaranalytics.com.au/api/v3/site_status/{{-
+  - resource_template: https://portal.solaranalytics.com.au/api/v4/site_status/{{-
       states('input_text.sa_site_id') 
       -}}
     headers: 
@@ -353,6 +353,10 @@ rest:
           - "mer_percentage"
           - "mer_status"
           - "mer_text"
+          - "fault_exists"
+          - "fault_type"
+          - "fault_class"
+          - "event_type"
 
   #
   # Solar Analytics - get the site fault status for the specified site_id.

--- a/solar_analytics_3phase.yaml
+++ b/solar_analytics_3phase.yaml
@@ -333,7 +333,7 @@ rest:
   #
   # Solar Analytics - get the site status for the specified site_id.
   # Updated every hour.
-  - resource_template: https://portal.solaranalytics.com.au/api/v3/site_status/{{-
+  - resource_template: https://portal.solaranalytics.com.au/api/v4/site_status/{{-
       states('input_text.sa_site_id') 
       -}}
     headers: 
@@ -353,6 +353,10 @@ rest:
           - "mer_percentage"
           - "mer_status"
           - "mer_text"
+          - "fault_exists"
+          - "fault_type"
+          - "fault_class"
+          - "event_type"
 
   #
   # Solar Analytics - get the site fault status for the specified site_id.

--- a/solar_analytics_advanced.yaml
+++ b/solar_analytics_advanced.yaml
@@ -333,7 +333,7 @@ rest:
   #
   # Solar Analytics - get the site status for the specified site_id.
   # Updated every hour.
-  - resource_template: https://portal.solaranalytics.com.au/api/v3/site_status/{{-
+  - resource_template: https://portal.solaranalytics.com.au/api/v4/site_status/{{-
       states('input_text.sa_site_id') 
       -}}
     headers: 
@@ -353,6 +353,10 @@ rest:
           - "mer_percentage"
           - "mer_status"
           - "mer_text"
+          - "fault_exists"
+          - "fault_type"
+          - "fault_class"
+          - "event_type"
 
   #
   # Solar Analytics - get the site fault status for the specified site_id.


### PR DESCRIPTION
My SA instance is offline (again 😔) and I was looking into the data that is exposed by the integration only to notice that it didn't report the `fault_exists` property from `site_status`.

I think this is because that wasn't in the v3 API, so I've updated that part to v4 and added a few more sensors that v4 provides.

This means you can have an automation do something like "if {{ state_attr('sensors.sa_status', 'fault_exists') }} <do someting>`.